### PR TITLE
Make mlock() and munlock() portable to systems that require the address to be on a page boundry.

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -36,6 +36,20 @@ typedef unsigned long long  uint64;
 // the pagefile except in rare circumstances where memory is extremely low.
 #define mlock(p, n) VirtualLock((p), (n));
 #define munlock(p, n) VirtualUnlock((p), (n));
+#else
+#include <limits.h>
+#include <sys/mman.h>
+/* This comes from limits.h if it's not defined there set a sane default */
+#ifndef PAGESIZE
+#include <unistd.h>
+#define PAGESIZE sysconf(_SC_PAGESIZE)
+#endif
+#define mlock(a,b) \
+  mlock(((void *)(((size_t)(a)) & ((size_t)(((PAGESIZE)<<1)-1)))),\
+  (b) + ((size_t)(a) - (((size_t)(a)) & ((size_t)(((PAGESIZE)<<1)-1)))))
+#define munlock(a,b) \
+  munlock(((void *)(((size_t)(a)) & ((size_t)(((PAGESIZE)<<1)-1)))),\
+  (b) + ((size_t)(a) - (((size_t)(a)) & ((size_t)(((PAGESIZE)<<1)-1)))))
 #endif
 
 class CScript;


### PR DESCRIPTION
Make mlock() and munlock() portable to systems that require the address to be on a page boundry.

This is applicable to osx, *bsd, and I think solaris.

This commit moves the windows-related macros to serialize.h so that they will get included in the right place properly and defines a new set for posix based systems that ensures the given address begins on a page boundary.
